### PR TITLE
Add Exponential Retries for Upload/Download

### DIFF
--- a/src/Tc.Psg.CloudFtpBridge/Tc.Psg.CloudFtpBridge.csproj
+++ b/src/Tc.Psg.CloudFtpBridge/Tc.Psg.CloudFtpBridge.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="LiteDB" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Polly" Version="6.0.1" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.1" />
     <PackageReference Include="Tc.Psg.Logging" Version="1.1.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds retry policies for FTP uploads and downloads. If an FtpException is thrown, the policy with retry up to 5 times with an exponential back-off (waiting up to 32 seconds for the 5th retry).

Closes #7