### PR TITLE
Improve Polling Loop Resiliency

### DIFF
--- a/installer/CloudFtpBridge.iss
+++ b/installer/CloudFtpBridge.iss
@@ -2,8 +2,8 @@
 #define AppCopyright "Copyright (c) 2017, TrueCommerce PSG Engineering"
 #define AppName "Cloud FTP Bridge"
 #define AppServiceName "TcCloudFtpBridge"
-#define AppVersion "2.1.1"
-#define AppVersionStrict "2.1.1.0"
+#define AppVersion "2.2.0"
+#define AppVersionStrict "2.2.0.0"
 
 [Setup]
 AppName={#AppName}

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -14,5 +14,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.1.0")]
-[assembly: AssemblyFileVersion("2.1.1")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0")]

--- a/src/Tc.Psg.CloudFtpBridge.Service/Tc.Psg.CloudFtpBridge.Service.csproj
+++ b/src/Tc.Psg.CloudFtpBridge.Service/Tc.Psg.CloudFtpBridge.Service.csproj
@@ -119,5 +119,10 @@
   <ItemGroup>
     <Content Include="favicon.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Polly">
+      <Version>6.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This PR adds more retry policies to improve the resiliency of the polling loop. The outer loop itself will retry forever until the service is stopped.